### PR TITLE
Fix build script errors

### DIFF
--- a/mobile-app/android/settings.gradle
+++ b/mobile-app/android/settings.gradle
@@ -1,7 +1,7 @@
-pluginManagement { includeBuild("../../../node_modules/@react-native/gradle-plugin") }
+pluginManagement { includeBuild("../../node_modules/@react-native/gradle-plugin") }
 plugins { id("com.facebook.react.settings") }
 extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
 rootProject.name = 'MindfulMeals'
-apply from: file("../../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle")
-applyNativeModulesSettingsGradle(settings, "../../../")
+apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle")
+applyNativeModulesSettingsGradle(settings, "../../")
 include ':app'

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "npm run test --workspaces",
     "lint": "npm run lint --workspaces",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "prepare": "husky install",
+    "prepare": "if command -v husky >/dev/null 2>&1; then husky install || true; else echo 'Skipping husky install (husky not found)'; fi",
     "start:mobile": "cd mobile-app && npm start",
     "start:backend": "cd backend && npm run dev",
     "install:mobile": "npm install --workspace mobile-app",


### PR DESCRIPTION
Corrects Android Gradle plugin paths and hardens the root `prepare` script to fix build failures related to missing modules and Husky.

The Android build failed because `settings.gradle` used an incorrect relative path (`../../../`) to locate the `@react-native/gradle-plugin` within the monorepo's `node_modules`, leading to a "does not exist" error. Additionally, the root `package.json`'s `prepare` script would fail if `husky` was not installed (e.g., in a production build), causing "husky: command not found". These changes resolve both issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-dd64e2a0-219a-4d8e-ac6c-a8dad6db1575">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dd64e2a0-219a-4d8e-ac6c-a8dad6db1575">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

